### PR TITLE
Use the same session for Lichess API requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ python-chess==0.23.1
 PyYAML==3.12
 requests==2.18.4
 urllib3==1.22
+backoff==1.5.0


### PR DESCRIPTION
Changes non-streaming Lichess requests to use a Session object to improve performance with connection pooling.

Future changes can move the auth header into the Session object too, but I'll keep this PR small.