### PR TITLE
Stop challenges from going through backoff if they have been withdrawn

### DIFF
--- a/main.py
+++ b/main.py
@@ -61,8 +61,12 @@ def start(li, user_profile, max_games, max_queued, engine_factory, config):
                     challenge_queue.append(chlng)
                     print("    Queue {}".format(chlng.show()))
                 else:
-                    print("    Decline {}".format(chlng.show()))
-                    li.decline_challenge(chlng.id)
+                    try:
+                        response = li.decline_challenge(chlng.id)
+                        print("    Decline {}".format(chlng.show()))
+                    except HTTPError as exception:
+                        if exception.response.status_code == 404:
+                            print("    Withdrawn {}".format(chlng.show()))
             elif event["type"] == "gameStart":
                 if queued_processes <= 0:
                     print("Something went wrong. Game is starting and we don't have a queued process")
@@ -75,12 +79,15 @@ def start(li, user_profile, max_games, max_queued, engine_factory, config):
 
             if (queued_processes + busy_processes) < max_games and challenge_queue :
                 chlng = challenge_queue.pop(0)
-                print("    Accept {}".format(chlng.show()))
-                response = li.accept_challenge(chlng.id)
-                if response is not None:
-                    # TODO: Probably warrants better checking.
+                try:
+                    response = li.accept_challenge(chlng.id)
+                    print("    Accept {}".format(chlng.show()))
                     queued_processes += 1
                     print("--- Process Queue. Total Queued: {}. Total Used: {}".format(queued_processes, busy_processes))
+                except HTTPError as exception:
+                    if exception.response.status_code == 404:
+                        print("    Withdrawn {}".format(chlng.show()))
+
 
     control_stream.terminate()
     control_stream.join()


### PR DESCRIPTION
Due to a side-effect of #42 challenges which are either:
- next to be accepted in the queue but have been withdrawn, or
- withdrawn before the bot can decline them
will return a 404 when the POST request is sent to the lichess api.

Because of the backoff code in #42, each withdrawn challenge can take 20s to process.
This is a kinda ugly fix but this PR excludes them from the backoff code.