### PR TITLE
Configure UCI_Chess960 option if and only if playing chess960

### DIFF
--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -108,20 +108,29 @@ class UCIEngine(EngineWrapper):
         if options:
             self.engine.setoption(options)
 
-        self.engine.setoption({"UCI_Variant": type(board).uci_variant})
+        self.engine.setoption({
+            "UCI_Variant": type(board).uci_variant,
+            "UCI_Chess960": board.chess960
+        })
         self.engine.position(board)
 
         info_handler = chess.uci.InfoHandler()
         self.engine.info_handlers.append(info_handler)
 
     def first_search(self, board, movetime):
-        self.engine.setoption({"UCI_Variant": type(board).uci_variant})
+        self.engine.setoption({
+            "UCI_Variant": type(board).uci_variant,
+            "UCI_Chess960": board.chess960
+        })
         self.engine.position(board)
         best_move, _ = self.engine.go(movetime=movetime)
         return best_move
 
     def search(self, board, wtime, btime, winc, binc):
-        self.engine.setoption({"UCI_Variant": type(board).uci_variant})
+        self.engine.setoption({
+            "UCI_Variant": type(board).uci_variant,
+            "UCI_Chess960": board.chess960
+        })
         self.engine.position(board)
         best_move, _ = self.engine.go(
             wtime=wtime,

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -118,19 +118,11 @@ class UCIEngine(EngineWrapper):
         self.engine.info_handlers.append(info_handler)
 
     def first_search(self, board, movetime):
-        self.engine.setoption({
-            "UCI_Variant": type(board).uci_variant,
-            "UCI_Chess960": board.chess960
-        })
         self.engine.position(board)
         best_move, _ = self.engine.go(movetime=movetime)
         return best_move
 
     def search(self, board, wtime, btime, winc, binc):
-        self.engine.setoption({
-            "UCI_Variant": type(board).uci_variant,
-            "UCI_Chess960": board.chess960
-        })
         self.engine.position(board)
         best_move, _ = self.engine.go(
             wtime=wtime,


### PR DESCRIPTION
Since `UCI_Chess960` incurs some overhead in engines when set to true, rather than configuring it to `true` in `config.yml` for engines which support chess960, instead set it when chess960 is being played.