### PR TITLE
Add option for lczero to create a debug log file.

### DIFF
--- a/config.yml.default
+++ b/config.yml.default
@@ -33,6 +33,7 @@ engine:                      # engine settings
 #   gpu: 0                   # which GPU to use
 #   tempdecay: 15            # ?
 #   noise: true              # ?
+#   log: "./engines/log.txt" # save log of lczero debug output
   silence_stderr: false      # some engines (yes you, leela) are very noisy
 
 abort_time: 20               # time to abort a game in seconds when there is no activity

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -27,6 +27,9 @@ def create_engine(config, board):
             commands.append(str(lczero_options["tempdecay"]))
         if lczero_options.get("noise"):
             commands.append("--noise")
+        if "log" in lczero_options:
+            commands.append("--logfile")
+            commands.append(lczero_options["log"])
 
     silence_stderr = cfg.get("silence_stderr", False)
 


### PR DESCRIPTION
Added option to start lczero with command line option that writes debug output to a log file named log.txt in the ./engines/ directory.