### PR TITLE
removed \n and .lstrip() for ascii-art

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -267,13 +267,13 @@ def update_board(board, move):
     return board
 
 def intro():
-    return r"""\n
+    return r"""
     .   _/|
     .  // o\
     .  || ._)  lichess-bot %s
     .  //__\
     .  )___(   Play on Lichess with a bot
-    """.lstrip() % __version__
+    """ % __version__
 
 if __name__ == "__main__":
     enable_color_logging(logging.INFO)


### PR DESCRIPTION
Hey,
[jlherren](https://github.com/jlherren) noticed that the `\n` in the ASCII-Art was displayed, referring to https://github.com/careless25/lichess-bot/pull/156.
It's possible to display the knight properly by removing `.lstrip() `.

Best
~QueensGambit