### PR TITLE
Use correct Xboard time control for first move

### DIFF
--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -164,7 +164,7 @@ class XBoardEngine(EngineWrapper):
 
     def first_search(self, board, movetime):
         self.engine.setboard(board)
-        self.engine.level(0, 0, movetime / 1000, 0)
+        self.engine.st(movetime / 1000)
         bestmove = self.engine.go()
 
         return bestmove


### PR DESCRIPTION
The level command indicates the time for the whole game. The st command
correctly sets the clock time for just the next move.

Fixes #177 