### PR TITLE
Send Xboard engines last move instead of board FEN

### DIFF
--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -170,6 +170,7 @@ class XBoardEngine(EngineWrapper):
         return bestmove
 
     def search(self, board, wtime, btime, winc, binc):
+        self.engine.force()
         try:
             self.engine.usermove(board.peek())
         except IndexError:

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -170,7 +170,10 @@ class XBoardEngine(EngineWrapper):
         return bestmove
 
     def search(self, board, wtime, btime, winc, binc):
-        self.engine.setboard(board)
+        try:
+            self.engine.usermove(board.peek())
+        except IndexError:
+            self.engine.setboard(board)
         if board.turn == chess.WHITE:
             self.engine.time(wtime / 10)
             self.engine.otim(btime / 10)


### PR DESCRIPTION
This will allow Xboard engines to track the game history for move
repetitions and other purposes.

Fixes #178 